### PR TITLE
core: shared FairData API client + geometry helpers

### DIFF
--- a/core/fairdata_api.rb
+++ b/core/fairdata_api.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'json'
+require 'uri'
+
+# Shared FairData (Core Data Cloud) REST API client used by per-project setup
+# scripts (e.g. scripts/<project>/setup_project.rb).
+#
+# Staging and production run Clerk auth (VITE_AUTH_PROVIDER=clerk). Non-browser
+# clients must send `User-Agent: node` (or `Server: Netlify`) so the connector's
+# is_clerk? returns false and routes to JWT/password auth instead of expecting a
+# Clerk session cookie — required on EVERY request, including /auth/login.
+#
+# Ruby 2.6 compatible (no endless methods / pattern matching) so it can run
+# under system Ruby without bundler.
+module FairDataApi
+  USER_AGENT = 'node'
+
+  class Client
+    attr_reader :base_url
+
+    def initialize(base_url)
+      @base_url = base_url
+      @token = nil
+    end
+
+    # POST /auth/login -> stores and returns the JWT.
+    def login(email, password)
+      result = request(:post, '/auth/login', { email: email, password: password }, nil)
+      @token = result['token']
+      raise "Login failed: no token in response" if @token.nil? || @token.empty?
+      @token
+    end
+
+    def get(path)                 ; request(:get, path) ; end
+    def post(path, body = nil)    ; request(:post, path, body) ; end
+    def put(path, body = nil)     ; request(:put, path, body) ; end
+    def patch(path, body = nil)   ; request(:patch, path, body) ; end
+    def delete(path)              ; request(:delete, path) ; end
+
+    private
+
+    def request(method, path, body = nil, token = :use_session)
+      uri = URI("#{@base_url}#{path}")
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+
+      req = case method
+            when :get    then Net::HTTP::Get.new(uri)
+            when :post   then Net::HTTP::Post.new(uri)
+            when :put    then Net::HTTP::Put.new(uri)
+            when :patch  then Net::HTTP::Patch.new(uri)
+            when :delete then Net::HTTP::Delete.new(uri)
+            else raise ArgumentError, "unsupported method #{method}"
+            end
+
+      req['Content-Type'] = 'application/json'
+      req['Accept'] = 'application/json'
+      req['User-Agent'] = USER_AGENT
+
+      effective_token = token == :use_session ? @token : token
+      req['Authorization'] = "Bearer #{effective_token}" if effective_token
+
+      req.body = body.to_json if body
+
+      res = http.request(req)
+      unless res.code.to_i.between?(200, 299)
+        raise "API #{method.to_s.upcase} #{path} returned #{res.code}: #{res.body && res.body.slice(0, 500)}"
+      end
+
+      begin
+        JSON.parse(res.body)
+      rescue StandardError
+        {}
+      end
+    end
+  end
+
+  # The API doesn't return UDF labels, so match created UDFs to their code
+  # definitions by `order` (which we control at creation time). Returns
+  # { env_key => uuid }. Each def is a Hash with an :env key.
+  def self.map_udfs_by_order(udf_defs, api_udfs)
+    sorted = (api_udfs || []).sort_by { |u| u['order'].to_i }
+    map = {}
+    udf_defs.each_with_index do |udf_def, i|
+      map[udf_def[:env]] = sorted[i]['uuid'] if sorted[i]
+    end
+    map
+  end
+end

--- a/core/geo.rb
+++ b/core/geo.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'json'
+
+# Shared geometry helpers for FairData migrations.
+#
+# nodegoat (and GeoJSON generally) order coordinates [longitude, latitude];
+# FairData stores latitude/longitude — so every accessor here returns
+# [latitude, longitude]. Also provides circle-polygon radius math for
+# positional uncertainty (certainty_radius), derived from turf-style circle
+# polygons whose vertices are ~equidistant from the center.
+#
+# Ruby 2.6 compatible.
+module Geo
+  EARTH_RADIUS_KM = 6371.0088
+
+  module_function
+
+  # Great-circle distance in km between two [lon, lat] points.
+  def haversine_km(lon1, lat1, lon2, lat2)
+    rad = ->(deg) { deg * Math::PI / 180.0 }
+    dlat = rad.call(lat2 - lat1)
+    dlon = rad.call(lon2 - lon1)
+    a = (Math.sin(dlat / 2)**2) +
+        (Math.cos(rad.call(lat1)) * Math.cos(rad.call(lat2)) * (Math.sin(dlon / 2)**2))
+    2 * EARTH_RADIUS_KM * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+  end
+
+  # Centroid of a ring [[lon, lat], ...] -> [latitude, longitude] (rounded to 6dp).
+  # Drops the closing duplicate vertex if present.
+  def centroid(ring)
+    return [nil, nil] if ring.nil? || ring.empty?
+    verts = ring.last == ring.first ? ring[0..-2] : ring
+    return [nil, nil] if verts.empty?
+    lon = verts.map { |p| p[0].to_f }.sum / verts.length
+    lat = verts.map { |p| p[1].to_f }.sum / verts.length
+    [lat.round(6), lon.round(6)]
+  end
+
+  # Mean radius (km) of a circle polygon ring [[lon, lat], ...], measured from
+  # its centroid. turf.circle() vertices are ~equidistant; averaging smooths
+  # float drift.
+  def polygon_radius_km(ring)
+    return 0.0 if ring.nil? || ring.empty?
+    verts = ring.last == ring.first ? ring[0..-2] : ring
+    return 0.0 if verts.empty?
+    clon = verts.map { |p| p[0].to_f }.sum / verts.length
+    clat = verts.map { |p| p[1].to_f }.sum / verts.length
+    distances = verts.map { |p| haversine_km(clon, clat, p[0].to_f, p[1].to_f) }
+    distances.sum / distances.length
+  end
+
+  # Parse a GeoJSON geometry string -> [latitude, longitude].
+  # Point -> its coordinates; Polygon / GeometryCollection -> centroid of the
+  # (collected) vertices. Returns [nil, nil] on empty/unparseable input.
+  def parse_point(geojson)
+    return [nil, nil] if geojson.nil? || geojson.to_s.strip.empty?
+    geo = JSON.parse(geojson)
+    case geo['type']
+    when 'Point'
+      lon, lat = geo['coordinates']
+      [lat, lon]
+    when 'Polygon'
+      centroid(geo.dig('coordinates', 0))
+    when 'GeometryCollection'
+      pts = (geo['geometries'] || []).flat_map { |g| member_coords(g) }
+      centroid(pts)
+    else
+      [nil, nil]
+    end
+  rescue JSON::ParserError
+    [nil, nil]
+  end
+
+  def member_coords(geom)
+    case geom['type']
+    when 'Point'   then [geom['coordinates']]
+    when 'Polygon' then geom.dig('coordinates', 0) || []
+    else []
+    end
+  end
+end


### PR DESCRIPTION
Promotes code duplicated across the marronage and relnet migration scripts into the common `core/` library.

- **`core/fairdata_api.rb`** — `FairDataApi::Client` (login + request helpers, with the `User-Agent: node` Clerk-bypass baked in) and `map_udfs_by_order`.
- **`core/geo.rb`** — `haversine_km`, `centroid`, `polygon_radius_km`, `parse_point` (GeoJSON `[lon,lat]` → `[lat,lon]`; Point/Polygon/GeometryCollection).

Self-contained (adds files only). The **relnet (#10)** and **marronage (#11)** PRs are stacked on this and drop their duplicated copies — merge this first, then rebase those onto master.

Ruby 2.6 compatible so `setup_project.rb` runs under system Ruby.